### PR TITLE
后台：表单管理优化

### DIFF
--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -38,9 +38,9 @@ class FormController extends GyListController
             ->addTopButton('addnew')
             ->addTableColumn('title', '表单标题', '', '', false)
             ->addTableColumn('right_button', '操作', 'btn')
-            ->addRightButton('edit')
+            ->addRightButton('self',array('title' => '编辑', 'href' => U('edit', array('id' => '__data_id__')),'class'=>'label label-primary ajax-get confirm','confirm-msg'=>'该操作会可能造成已填写的用户数据混乱，请慎重操作'))
             ->addRightButton('self',array('title' => '编辑表单项', 'href' => U('FormItem/index', array('id' => '__data_id__')), 'class' => 'label label-success'))
-            ->addRightButton('delete')
+            ->addRightButton('delete',array('confirm-msg'=>'该操作会可能造成已填写的用户数据混乱，请慎重操作'))
             ->setTableDataList($data_list)
             ->setTableDataPage($page->show())
             ->display();
@@ -72,6 +72,9 @@ class FormController extends GyListController
     public function edit(){
         $model = new FormModel();
         $id=I('get.id');
+        if(IS_AJAX){
+            $this->success('',U('',['id'=>$id]));
+        }
         if (IS_POST){
             $data=I('post.');
             $data['create_date']=time();

--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -72,9 +72,7 @@ class FormController extends GyListController
     public function edit(){
         $model = new FormModel();
         $id=I('get.id');
-        if(IS_AJAX){
-            $this->success('',U('',['id'=>$id]));
-        }
+
         if (IS_POST){
             $data=I('post.');
             $data['create_date']=time();
@@ -84,6 +82,9 @@ class FormController extends GyListController
                 $this->error('保存失败'.D('Form')->getError(),U('index'));
             }
         }else{
+            if(IS_AJAX){
+                $this->success('',U('',['id'=>$id]));
+            }
             $data=$model->getOne($id);
             $builder=new FormBuilder();
             $builder->setMetaTitle('编辑表单')


### PR DESCRIPTION
删除正在使用的表单 的表单项时（不是编辑表单），在默认确认弹窗增加提醒文字：“该操作会可能造成已填写的用户数据混乱，请慎重操作！”



编辑正在使用的表单 的表单项时（不是编辑表单），点击  编辑、或在编辑保存时，也增加上述提示